### PR TITLE
Migrate from torch.nn.functional.{sigmoid,tanh} to torch.{sigmoid,tanh}

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,5 +1,5 @@
 import random
-import torch.nn.functional as F
+import torch
 from tensorboardX import SummaryWriter
 from plotting_utils import plot_alignment_to_numpy, plot_spectrogram_to_numpy
 from plotting_utils import plot_gate_outputs_to_numpy
@@ -44,5 +44,5 @@ class Tacotron2Logger(SummaryWriter):
             "gate",
             plot_gate_outputs_to_numpy(
                 gate_targets[idx].data.cpu().numpy(),
-                F.sigmoid(gate_outputs[idx]).data.cpu().numpy()),
+                torch.sigmoid(gate_outputs[idx]).data.cpu().numpy()),
             iteration)

--- a/model.py
+++ b/model.py
@@ -56,7 +56,7 @@ class Attention(nn.Module):
 
         processed_query = self.query_layer(query.unsqueeze(1))
         processed_attention_weights = self.location_layer(attention_weights_cat)
-        energies = self.v(F.tanh(
+        energies = self.v(torch.tanh(
             processed_query + processed_attention_weights + processed_memory))
 
         energies = energies.squeeze(-1)
@@ -141,7 +141,7 @@ class Postnet(nn.Module):
 
     def forward(self, x):
         for i in range(len(self.convolutions) - 1):
-            x = self.dropout(F.tanh(self.convolutions[i](x)))
+            x = self.dropout(torch.tanh(self.convolutions[i](x)))
 
         x = self.dropout(self.convolutions[-1](x))
 
@@ -436,7 +436,7 @@ class Decoder(nn.Module):
             gate_outputs += [gate_output.squeeze(1)]
             alignments += [alignment]
 
-            if F.sigmoid(gate_output.data) > self.gate_threshold:
+            if torch.sigmoid(gate_output.data) > self.gate_threshold:
                 break
             elif len(mel_outputs) == self.max_decoder_steps:
                 print("Warning! Reached max decoder steps")


### PR DESCRIPTION
As of PyTorch 0.4.1, the following deprecation warnings are printed when using the former functions:

```
/home/srs/miniconda3/envs/tacotron2/lib/python3.6/site-packages/torch/nn/functional.py:995: UserWarning: nn.functional.tanh is deprecated. Use torch.tanh instead.
  warnings.warn("nn.functional.tanh is deprecated. Use torch.tanh instead.")
```

```
/home/srs/miniconda3/envs/tacotron2/lib/python3.6/site-packages/torch/nn/functional.py:1006: UserWarning: nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
  warnings.warn("nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.")
```

`torch.tanh` and `torch.sigmoid` are already available in PyTorch 0.4.0, the version currently specified in `requirements.txt`.