### PR TITLE
Fix a dropout bug

### DIFF
--- a/model.py
+++ b/model.py
@@ -97,7 +97,7 @@ class Prenet(nn.Module):
 
     def forward(self, x):
         for linear in self.layers:
-            x = F.dropout(F.relu(linear(x)), p=0.5, training=True)
+            x = F.dropout(F.relu(linear(x)), p=0.5, training=self.training)
         return x
 
 


### PR DESCRIPTION
I notice that all the `dropout` functions use `self.training` as the last parameter except the one in `Prenet`, and I guess it is the cause of #146 .

Can someone please take a look? Thanks :)