### PR TITLE
[bug-fix] pillow dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 
 RUN apt-get update -y
 
-RUN pip install numpy scipy matplotlib librosa==0.6.0 tensorflow tensorboardX inflect==0.2.5 Unidecode==1.0.22 jupyter
+RUN pip install numpy scipy matplotlib librosa==0.6.0 tensorflow tensorboardX inflect==0.2.5 Unidecode==1.0.22 pillow jupyter
 
 ADD apex /apex/
 WORKDIR /apex/


### PR DESCRIPTION
The same as [requirements.txt](https://github.com/NVIDIA/tacotron2/blob/master/requirements.txt#L9)

Traceback:
```
Traceback (most recent call last):
  File "train.py", line 290, in <module> 
    args.warm_start, args.n_gpus, args.rank, args.group_name, hparams)
  File "train.py", line 248, in train
    hparams.distributed_run, rank)
  File "train.py", line 146, in validate 
    logger.log_validation(val_loss, model, y, y_pred, iteration)
  File "/workspace/tacotron2/logger.py", line 34, in log_validation
    iteration)
  File "/opt/conda/lib/python3.6/site-packages/tensorboardX/writer.py", line 584, in add_image
    image(tag, img_tensor, dataformats=dataformats), global_step, walltime)
  File "/opt/conda/lib/python3.6/site-packages/tensorboardX/summary.py", line 271, in image
    image = make_image(tensor, rescale=rescale)
  File "/opt/conda/lib/python3.6/site-packages/tensorboardX/summary.py", line 307, in make_image
    from PIL import Image
ModuleNotFoundError: No module named 'PIL'
```