### PR TITLE
fix error when batch size = 1

### DIFF
--- a/model.py
+++ b/model.py
@@ -407,7 +407,7 @@ class Decoder(nn.Module):
             mel_output, gate_output, attention_weights = self.decode(
                 decoder_input)
             mel_outputs += [mel_output.squeeze(1)]
-            gate_outputs += [gate_output.squeeze()]
+            gate_outputs += [gate_output.squeeze(1)]
             alignments += [attention_weights]
 
         mel_outputs, gate_outputs, alignments = self.parse_decoder_outputs(


### PR DESCRIPTION
This PR fix an error when `batch size = 1`. 

This is because the `squeeze` function without parameter will squeeze all dimensions of size 1.