### PR TITLE
remove tensorboardX; use torch.utils.tensorboard

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,6 +1,6 @@
 import random
 import torch
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 from plotting_utils import plot_alignment_to_numpy, plot_spectrogram_to_numpy
 from plotting_utils import plot_gate_outputs_to_numpy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ numpy==1.13.3
 inflect==0.2.5
 librosa==0.6.0
 scipy==1.0.0
-tensorboardX==1.1
 Unidecode==1.0.22
 pillow


### PR DESCRIPTION
This PR remove `tensorboardX` dependence and use `torch.utils.tensorboard` instead.