### PR TITLE
Remove half precision inference

### DIFF
--- a/inference.ipynb
+++ b/inference.ipynb
@@ -87,7 +87,7 @@
     "checkpoint_path = \"tacotron2_statedict.pt\"\n",
     "model = load_model(hparams)\n",
     "model.load_state_dict(torch.load(checkpoint_path)['state_dict'])\n",
-    "_ = model.cuda().eval().half()"
+    "_ = model.cuda().eval()"
    ]
   },
   {
@@ -111,7 +111,7 @@
    "source": [
     "waveglow_path = 'waveglow_256channels.pt'\n",
     "waveglow = torch.load(waveglow_path)['model']\n",
-    "waveglow.cuda().eval().half()\n",
+    "waveglow.cuda().eval()\n",
     "for k in waveglow.convinv:\n",
     "    k.float()\n",
     "denoiser = Denoiser(waveglow)"


### PR DESCRIPTION
Current Waveglow codebase is pushing all values to NAN. Half precision arithmetic doesn't work anymore.