### PR TITLE
migrate to tensorflow 2.3

### DIFF
--- a/hparams.py
+++ b/hparams.py
@@ -1,11 +1,39 @@
 import tensorflow as tf
 from text import symbols
 
+class HParams(object):
+    hparamdict = []
+    def __init__(self, **hparams):
+        self.hparamdict = hparams
+        for k, v in hparams.items():
+            setattr(self, k, v)
+    def __repr__(self):
+        return "HParams(" + repr([(k, v) for k, v in self.hparamdict.items()]) + ")"
+    def __str__(self):
+        return ','.join([(k + '=' + str(v)) for k, v in self.hparamdict.items()])
+    def parse(self, params):
+        for s in params.split(","):
+            k, v = s.split("=", 1)
+            k = k.strip()
+            t = type(self.hparamdict[k])
+            if t == bool:
+                v = v.strip().lower()
+                if v in ['true', '1']:
+                    v = True
+                elif v in ['false', '0']:
+                    v = False
+                else:
+                    raise ValueError(v)
+            else:
+                v = t(v)
+            self.hparamdict[k] = v
+            setattr(self, k, v)
+        return self
 
 def create_hparams(hparams_string=None, verbose=False):
     """Create model hyperparameters. Parse nondefault from given string."""
 
-    hparams = tf.contrib.training.HParams(
+    hparams = HParams(
         ################################
         # Experiment Parameters        #
         ################################
@@ -86,10 +114,10 @@ def create_hparams(hparams_string=None, verbose=False):
     )
 
     if hparams_string:
-        tf.logging.info('Parsing command line hparams: %s', hparams_string)
+        tf.compat.v1.logging.info('Parsing command line hparams: %s', hparams_string)
         hparams.parse(hparams_string)
 
     if verbose:
-        tf.logging.info('Final parsed hparams: %s', hparams.values())
+        tf.compat.v1.logging.info('Final parsed hparams: %s', hparams.values())
 
     return hparams

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==2.1.0
-tensorflow==1.15.2
+tensorflow>=2.3.0
 numpy==1.13.3
 inflect==0.2.5
 librosa==0.6.0


### PR DESCRIPTION
Hello NVIDIA team,
Please take a look at this tiny implementation of deprecated tf.contrib.training.HParams
I use it in Colab notebooks
Is it worth to be accepted?